### PR TITLE
startCase on the includes in proofRequest

### DIFF
--- a/packages/legacy/core/App/screens/ProofRequest.tsx
+++ b/packages/legacy/core/App/screens/ProofRequest.tsx
@@ -12,7 +12,6 @@ import {
   GetFormatDataReturn,
 } from '@aries-framework/core/build/modules/proofs/models/ProofServiceOptions'
 import { useAgent, useConnectionById, useProofById, useCredentials } from '@aries-framework/react-hooks'
-import startCase from 'lodash.startcase'
 import React, { useState, useMemo, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { View, StyleSheet, Text, DeviceEventEmitter, FlatList } from 'react-native'
@@ -216,7 +215,7 @@ const ProofRequest: React.FC<ProofRequestProps> = ({ navigation, route }) => {
         const credNamesInAttrs = fields[proofKey].map((attr) =>
           parseCredDefFromId(attr.credentialInfo?.credentialDefinitionId, attr.credentialInfo?.schemaId)
         )
-        if (credNamesInAttrs.includes(startCase(credName))) {
+        if (credNamesInAttrs.includes(credName)) {
           credFound = true
           return
         }


### PR DESCRIPTION
# Summary of Changes

This pull request addresses an issue where, despite having the required credential in the wallet, performing a proofRequest for a specific attribute would display the message "Not available in your wallet." 

![IMG_0244](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/24842909/e92a5a43-6da4-4628-a5c1-e7129a8f50e7)
![IMG_0245](https://github.com/hyperledger/aries-mobile-agent-react-native/assets/24842909/8e0c148f-585c-45d7-a797-eda8a6be9309)


# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
