### PR TITLE
fix: oob flow with goal_code "aries.vc.issue" or "aries.vc.verify"

### DIFF
--- a/packages/legacy/core/App/screens/Connection.tsx
+++ b/packages/legacy/core/App/screens/Connection.tsx
@@ -146,6 +146,7 @@ const Connection: React.FC<ConnectionProps> = ({ navigation, route }) => {
 
     if (
       connectionId &&
+      state.notificationRecord &&
       (!goalCode || (!goalCode.startsWith('aries.vc.verify') && !goalCode.startsWith('aries.vc.issue')))
     ) {
       // No goal code, we don't know what to expect next,


### PR DESCRIPTION
# Summary of Changes

This PR is to fix a problem related to the goal_code. Following the modification of [PR 955 ](https://github.com/hyperledger/aries-mobile-agent-react-native/pull/955) the behavior of the goal_code no longer works for our oob connections with `goal_code: "aries.vc.issue"` or `goal_code: "aries.vc.verify"` we end up in the chat flow.

# Related Issues

N/A

# Pull Request Checklist

Tick all boxes below to demonstrate that you have completed the respective task. If the item does not apply to your this PR **check it anyway** to make it apparent that there's nothing to do.

- [ ] All commits contain a DCO `Signed-off-by` line (we use the [DCO GitHub app](https://github.com/apps/dco) to enforce this);
- [ ] Updated LICENSE-3RD-PARTY.md for any added dependencies or vendored components;
- [ ] Updated documentation as needed for changed code and new or modified features;
- [ ] Added sufficient [tests](../__tests__/) so that overall code coverage is not reduced.

If you have _any_ questions to _any_ of the points above, just **submit and ask**! This checklist is here to _help_ you, not to deter you from contributing!

Pro Tip 🤓

- Read our [contribution guide](../CONTRIBUTING.md) at least once; it will save you a few review cycles!
- Your PR will likely not be reviewed until all the above boxes are checked and all automated tests have passed.

_PR template adapted from the Python attrs project._
